### PR TITLE
[cli] 検索機能の改善

### DIFF
--- a/cli/.env.example
+++ b/cli/.env.example
@@ -1,5 +1,5 @@
 GO_ENV=dev
 API_URI=http://api:8080/v1
-HOTPEPPER_API_URL=https://webservice.recruit.co.jp/hotpepper/gourmet/v1
+HOTPEPPER_API_URL=https://webservice.recruit.co.jp/hotpepper/
 HOTPEPPER_API_KEY=
 LINE_NOTIFY_API_URL=https://notify-api.line.me/api/notify

--- a/cli/api/client/hotpepper/http_client.go
+++ b/cli/api/client/hotpepper/http_client.go
@@ -8,10 +8,10 @@ import (
 	"time"
 )
 
-func HttpClient(method string, queryParams string, response interface{}) error {
+func HttpClient(method string, endpoint string, queryParams string, response interface{}) error {
 	uri := os.Getenv("HOTPEPPER_API_URL")
 	key := os.Getenv("HOTPEPPER_API_KEY")
-	req, err := http.NewRequest(method, uri+"/?key="+key+queryParams, nil)
+	req, err := http.NewRequest(method, uri+endpoint+"/?key="+key+queryParams, nil)
 	if err != nil {
 		return err
 	}

--- a/cli/api/factory/genre/genre.go
+++ b/cli/api/factory/genre/genre.go
@@ -1,0 +1,40 @@
+package genre
+
+import (
+	"fmt"
+
+	"github.com/Seiya-Tagami/pecopeco-cli/api/model"
+	"github.com/Seiya-Tagami/pecopeco-cli/api/repository/genre"
+)
+
+type GenreFactory interface {
+	ListGenres() ([]model.Genre, error)
+}
+
+type factory struct {
+	repository genre.Repository
+}
+
+func CreateFactory() GenreFactory {
+	repository := genre.New()
+	return &factory{repository}
+}
+
+func (f *factory) ListGenres() ([]model.Genre, error) {
+	res, err := f.repository.List()
+	if err != nil {
+		err := fmt.Errorf("Failed to implement List: %v", err)
+		return []model.Genre{}, err
+	}
+
+	genresList := make([]model.Genre, 0, res.Results.ResultsAvailable)
+
+	for _, v := range res.Results.Genre {
+		genre := model.Genre{
+			Name: v.Name,
+			Code: v.Code,
+		}
+		genresList = append(genresList, genre)
+	}
+	return genresList, nil
+}

--- a/cli/api/factory/genre/genre.go
+++ b/cli/api/factory/genre/genre.go
@@ -27,14 +27,14 @@ func (f *factory) ListGenres() ([]model.Genre, error) {
 		return []model.Genre{}, err
 	}
 
-	genresList := make([]model.Genre, 0, res.Results.ResultsAvailable)
+	genreList := make([]model.Genre, 0, len(res.Results.Genre))
 
 	for _, v := range res.Results.Genre {
 		genre := model.Genre{
 			Name: v.Name,
 			Code: v.Code,
 		}
-		genresList = append(genresList, genre)
+		genreList = append(genreList, genre)
 	}
-	return genresList, nil
+	return genreList, nil
 }

--- a/cli/api/factory/restaurant/params.go
+++ b/cli/api/factory/restaurant/params.go
@@ -3,8 +3,8 @@ package restaurant
 import "github.com/Seiya-Tagami/pecopeco-cli/api/model"
 
 type ListRestaurantsParams struct {
-	City string
-	Food string
+	City  string
+	Genre string
 }
 
 type NotifyRestaurantToLINEParams struct {

--- a/cli/api/factory/restaurant/restaurant.go
+++ b/cli/api/factory/restaurant/restaurant.go
@@ -23,8 +23,8 @@ func CreateFactory() RestaurantFactory {
 
 func (f *factory) ListRestaurants(params ListRestaurantsParams) ([]model.Restaurant, error) {
 	request := restaurant.ListRequest{
-		City: params.City,
-		Food: params.Food,
+		City:  params.City,
+		Genre: params.Genre,
 	}
 	res, err := f.repository.List(request)
 	if err != nil {

--- a/cli/api/model/genre.go
+++ b/cli/api/model/genre.go
@@ -1,0 +1,6 @@
+package model
+
+type Genre struct {
+	Name string
+	Code string
+}

--- a/cli/api/others/hotperpper_response_sample2.json
+++ b/cli/api/others/hotperpper_response_sample2.json
@@ -1,0 +1,27 @@
+{
+  "results": {
+    "api_version": "1.30",
+    "results_available": 17,
+    "results_returned": "17",
+    "results_start": 1,
+    "genre": [
+      { "code": "G001", "name": "居酒屋" },
+      { "code": "G002", "name": "ダイニングバー・バル" },
+      { "code": "G003", "name": "創作料理" },
+      { "code": "G004", "name": "和食" },
+      { "code": "G005", "name": "洋食" },
+      { "code": "G006", "name": "イタリアン・フレンチ" },
+      { "code": "G007", "name": "中華" },
+      { "code": "G008", "name": "焼肉・ホルモン" },
+      { "code": "G017", "name": "韓国料理" },
+      { "code": "G009", "name": "アジア・エスニック料理" },
+      { "code": "G010", "name": "各国料理" },
+      { "code": "G011", "name": "カラオケ・パーティ" },
+      { "code": "G012", "name": "バー・カクテル" },
+      { "code": "G013", "name": "ラーメン" },
+      { "code": "G016", "name": "お好み焼き・もんじゃ" },
+      { "code": "G014", "name": "カフェ・スイーツ" },
+      { "code": "G015", "name": "その他グルメ" }
+    ]
+  }
+}

--- a/cli/api/repository/genre/repository.go
+++ b/cli/api/repository/genre/repository.go
@@ -1,0 +1,23 @@
+package genre
+
+import (
+	"github.com/Seiya-Tagami/pecopeco-cli/api/client/hotpepper"
+)
+
+type Repository interface {
+	List() (ListResponse, error)
+}
+
+type repository struct{}
+
+func New() Repository {
+	return &repository{}
+}
+
+func (r *repository) List() (ListResponse, error) {
+	listResponse := ListResponse{}
+	if err := hotpepper.HttpClient("GET", "/genre/v1/", "&format=json", &listResponse); err != nil {
+		return ListResponse{}, err
+	}
+	return listResponse, nil
+}

--- a/cli/api/repository/genre/response.go
+++ b/cli/api/repository/genre/response.go
@@ -1,0 +1,11 @@
+package genre
+
+type ListResponse struct {
+	Results struct {
+		ResultsAvailable int `json:"results_available"`
+		Genre            []struct {
+			Code string `json:"code"`
+			Name string `json:"name"`
+		} `json:"genre"`
+	}
+}

--- a/cli/api/repository/restaurant/repository.go
+++ b/cli/api/repository/restaurant/repository.go
@@ -21,7 +21,7 @@ func New() Repository {
 
 func (r *repository) List(request ListRequest) (ListResponse, error) {
 	listResponse := ListResponse{}
-	if err := hotpepper.HttpClient("GET", fmt.Sprintf("&keyword=%s,%s&count=100&format=json", request.City, request.Food), &listResponse); err != nil {
+	if err := hotpepper.HttpClient("GET", "/gourmet/v1/", fmt.Sprintf("&keyword=%s&genre=%s&count=100&format=json", request.City, request.Genre), &listResponse); err != nil {
 		return ListResponse{}, err
 	}
 	return listResponse, nil

--- a/cli/api/repository/restaurant/request.go
+++ b/cli/api/repository/restaurant/request.go
@@ -1,8 +1,8 @@
 package restaurant
 
 type ListRequest struct {
-	City string
-	Food string
+	City  string
+	Genre string
 }
 
 type NotifyToLINERequest struct {


### PR DESCRIPTION
## 関連 issue
- issue close #19
 
## 説明
- 検索機能の改善を行いました。
- 具体的には、
①場所は`> Which city? (Japanese only, ex.渋谷)`というように質問し、入力してもらうようにしました。
②食べ物ではなくジャンルをセレクトで選んでもらうようにし、そのジャンルの値はホットペッパーAPIが用意しているジャンルのエンドポイントから取得しています。
- ジャンルで絞るようにしたので、以前より検索ヒット数が安定するようになりました。
<img width="400" alt="image" src="https://github.com/Seiya-Tagami/pecopeco/assets/107479598/9b68bc87-3af7-4eca-8eb6-8d34d885d80e">

## 動作確認手順
1. `.env.example`の`HOTPEPPER_API_URL`の値が更新されているのでコピペして`.env`に張り付けます。
2. アプリケーションを立ち上げます。
```
$ make run-cli
$ make it-cli
$ go run main.go run
```
3. 検索機能を利用します。
```
1. Search foodを選択します。
2. 渋谷と打ち、好きなジャンルを選択します。
3. 検索結果が表示されます。
```

## 相談したいこと

## 確認して欲しいこと
- 気になる点の指摘をよろしくお願いいたします！

## 参考 URL 等
