### PR TITLE
hotfix: 返り値のミスを修正

### DIFF
--- a/service/internal/usecase/user/login_usecase.go
+++ b/service/internal/usecase/user/login_usecase.go
@@ -46,7 +46,11 @@ func (uc *LoginUsecase) Run(ctx context.Context, dto LoginUseCaseInputDto) (*Log
 		return nil, err
 	}
 	if exists {
-		return nil, nil
+		return &LoginUseCaseOutputDto{
+			ID:    user.ID,
+			Name:  user.Name,
+			Email: user.Email,
+		}, nil
 	}
 
 	tx, err := db.GetDB().Begin()
@@ -67,6 +71,6 @@ func (uc *LoginUsecase) Run(ctx context.Context, dto LoginUseCaseInputDto) (*Log
 	return &LoginUseCaseOutputDto{
 		ID:    user.ID,
 		Name:  user.Name,
-		Email: user.ID,
+		Email: user.Email,
 	}, nil
 }


### PR DESCRIPTION
## 関連 issue
なし

## 説明
- `login_usecase.go`の返り値にミスがあったため修正です。

## 動作確認手順

## 相談したいこと

## 確認して欲しいこと

## 参考 URL 等
