### PR TITLE
[cli] cliとuserのapiとのつなぎこみを実装

### DIFF
--- a/cli/api/factory/user/params.go
+++ b/cli/api/factory/user/params.go
@@ -1,0 +1,7 @@
+package user
+
+type LoginParams struct {
+	ID    string
+	Name  string
+	Email string
+}

--- a/cli/api/factory/user/user.go
+++ b/cli/api/factory/user/user.go
@@ -1,0 +1,55 @@
+package user
+
+import (
+	"fmt"
+
+	"github.com/Seiya-Tagami/pecopeco-cli/api/model"
+	"github.com/Seiya-Tagami/pecopeco-cli/api/repository/user"
+)
+
+type UserFactory interface {
+	FindUser() (model.User, error)
+	Login(params LoginParams) (model.User, error)
+}
+
+type factory struct {
+	repository user.Repository
+}
+
+func CreateFactory() UserFactory {
+	repository := user.New()
+	return &factory{repository}
+}
+
+func (f *factory) FindUser() (model.User, error) {
+	response, err := f.repository.Get()
+	if err != nil {
+		err := fmt.Errorf("Failed to implement Get: %v", err)
+		return model.User{}, err
+	}
+	user := model.User{
+		ID:    response.ID,
+		Name:  response.Name,
+		Email: response.Email,
+	}
+	return user, nil
+}
+
+func (f *factory) Login(params LoginParams) (model.User, error) {
+	request := user.LoginRequest{
+		ID:    params.ID,
+		Name:  params.Name,
+		Email: params.Email,
+	}
+	response, err := f.repository.Create(request)
+	if err != nil {
+		err := fmt.Errorf("Failed to implement Create: %v", err)
+		return model.User{}, err
+	}
+	user := model.User{
+		ID:    response.ID,
+		Name:  response.Name,
+		Email: response.Email,
+	}
+	return user, nil
+}

--- a/cli/api/model/user.go
+++ b/cli/api/model/user.go
@@ -1,0 +1,7 @@
+package model
+
+type User struct {
+	ID    string
+	Name  string
+	Email string
+}

--- a/cli/api/repository/user/repository.go
+++ b/cli/api/repository/user/repository.go
@@ -1,0 +1,32 @@
+package user
+
+import (
+	"github.com/Seiya-Tagami/pecopeco-cli/api/client/app"
+)
+
+type Repository interface {
+	Get() (FindUserResponse, error)
+	Create(request LoginRequest) (LoginResponse, error)
+}
+
+type repository struct{}
+
+func New() Repository {
+	return &repository{}
+}
+
+func (r *repository) Get() (FindUserResponse, error) {
+	findUserResponse := FindUserResponse{}
+	if err := app.HttpClient("GET", "/users/me", nil, &findUserResponse); err != nil {
+		return findUserResponse, err
+	}
+	return findUserResponse, nil
+}
+
+func (r *repository) Create(request LoginRequest) (LoginResponse, error) {
+	loginResponse := LoginResponse{}
+	if err := app.HttpClient("POST", "/users/login", request, &loginResponse); err != nil {
+		return loginResponse, err
+	}
+	return loginResponse, nil
+}

--- a/cli/api/repository/user/request.go
+++ b/cli/api/repository/user/request.go
@@ -1,0 +1,7 @@
+package user
+
+type LoginRequest struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}

--- a/cli/api/repository/user/response.go
+++ b/cli/api/repository/user/response.go
@@ -1,0 +1,13 @@
+package user
+
+type FindUserResponse struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+type LoginResponse struct {
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}

--- a/cli/auth/auth.go
+++ b/cli/auth/auth.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 
 	"github.com/Seiya-Tagami/pecopeco-cli/auth/util"
@@ -141,8 +140,6 @@ func (o *OAuth) Authorization(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	// XXX: For Dev
-	log.Println("Received code & state")
 
 	if authCode.state != state {
 		return errors.New("Failed to authorize. Invalid state")
@@ -158,8 +155,7 @@ func (o *OAuth) Authorization(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	// XXX: For Dev
-	log.Println("Exchange token")
+
 	o.Token = token
 
 	return nil

--- a/cli/auth/auth.go
+++ b/cli/auth/auth.go
@@ -7,8 +7,10 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/Seiya-Tagami/pecopeco-cli/auth/util"
+	"github.com/briandowns/spinner"
 	"github.com/go-chi/chi/v5"
 	"golang.org/x/oauth2"
 )
@@ -131,10 +133,15 @@ func (o *OAuth) Authorization(ctx context.Context) error {
 		oauth2.SetAuthURLParam("code_challenge_method", "S256"),
 	)
 
-	fmt.Printf("Logging into your Google account...\n\nClick following a URL: %v\n", url)
+	fmt.Printf("\nLogging into your Google account...\n\nPlease click following a URL: %v\n\n", url)
 	if err = util.OpenBrowser(url); err != nil {
 		fmt.Println(err)
 	}
+
+	sp := spinner.New(spinner.CharSets[21], 100*time.Millisecond)
+	sp.Color("green")
+	sp.Suffix = " Waiting for authentication..."
+	sp.Start()
 
 	authCode, err := s.getAuthCode()
 	if err != nil {
@@ -157,6 +164,8 @@ func (o *OAuth) Authorization(ctx context.Context) error {
 	}
 
 	o.Token = token
+
+	sp.Stop()
 
 	return nil
 }

--- a/cli/auth/auth.go
+++ b/cli/auth/auth.go
@@ -7,10 +7,9 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"time"
 
 	"github.com/Seiya-Tagami/pecopeco-cli/auth/util"
-	"github.com/briandowns/spinner"
+	"github.com/Seiya-Tagami/pecopeco-cli/ui"
 	"github.com/go-chi/chi/v5"
 	"golang.org/x/oauth2"
 )
@@ -138,9 +137,7 @@ func (o *OAuth) Authorization(ctx context.Context) error {
 		fmt.Println(err)
 	}
 
-	sp := spinner.New(spinner.CharSets[21], 100*time.Millisecond)
-	sp.Color("green")
-	sp.Suffix = " Waiting for authentication..."
+	sp := ui.DefaultSpinner("Waiting for authentication...")
 	sp.Start()
 
 	authCode, err := s.getAuthCode()

--- a/cli/auth/util/openBrowser.go
+++ b/cli/auth/util/openBrowser.go
@@ -21,7 +21,7 @@ func OpenBrowser(url string) error {
 		err = fmt.Errorf("unsupported platform.")
 	}
 	if err != nil {
-		return errors.New("\nSorry, could not open a browser. Open the link above in your browser to manually complete authentication.")
+		return errors.New("Sorry, could not open a browser. Open the link above in your browser to manually complete authentication.\n")
 	}
 	return nil
 }

--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Seiya-Tagami/pecopeco-cli/auth/secret"
 	"github.com/Seiya-Tagami/pecopeco-cli/config"
 	"github.com/Seiya-Tagami/pecopeco-cli/ui"
+	"github.com/briandowns/spinner"
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2/google"
 )
@@ -26,7 +27,6 @@ var loginCmd = &cobra.Command{
 
 func login() {
 	factory := user.CreateFactory()
-
 	// 既にログインしていた場合は処理をはじく。
 	if config.IsLogin() {
 		user, err := factory.FindUser()
@@ -66,6 +66,13 @@ func login() {
 		return
 	}
 
+	ui.TextGreen().Printf("Authentication complete.\n\n")
+
+	sp := spinner.New(spinner.CharSets[21], 100*time.Millisecond)
+	sp.Color("green")
+	sp.Suffix = " Logging in..."
+	sp.Start()
+
 	userinfo, err := userinfo.Get(ctx, oauth)
 	if err != nil {
 		fmt.Println(err)
@@ -84,6 +91,8 @@ func login() {
 		fmt.Println(err)
 		return
 	}
+
+	sp.Stop()
 	ui.TextGreen().Printf("Successfully login as %s, %s\n", response.Name, response.Email)
 }
 

--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Seiya-Tagami/pecopeco-cli/api/factory/user"
 	"github.com/Seiya-Tagami/pecopeco-cli/auth"
 	"github.com/Seiya-Tagami/pecopeco-cli/auth/api/userinfo"
 	"github.com/Seiya-Tagami/pecopeco-cli/auth/secret"
+	"github.com/Seiya-Tagami/pecopeco-cli/config"
+	"github.com/Seiya-Tagami/pecopeco-cli/ui"
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2/google"
 )
@@ -22,6 +25,23 @@ var loginCmd = &cobra.Command{
 }
 
 func login() {
+	factory := user.CreateFactory()
+
+	// 既にログインしていた場合は処理をはじく。
+	if config.IsLogin() {
+		user, err := factory.FindUser()
+		if err != nil {
+			ui.TextBlue().Println(errorMsg)
+			return
+		}
+		ui.TextBlue().Printf(
+			"You have already logged in as %s, %s.\nTo log in to another account, please log out of your current account first.\n",
+			user.Name,
+			user.Email,
+		)
+		return
+	}
+
 	id, secret, scopes, redirectURL, err := secret.Load()
 	if err != nil {
 		fmt.Println(err)
@@ -51,10 +71,20 @@ func login() {
 		fmt.Println(err)
 		return
 	}
-	fmt.Printf("[ID] %s\n[Name] %s\n[Email] %s\n", userinfo.ID, userinfo.Name, userinfo.Email)
 
 	// ログイン処理
-	// ...
+	params := user.LoginParams{
+		ID:    userinfo.ID,
+		Name:  userinfo.Name,
+		Email: userinfo.Email,
+	}
+
+	response, err := factory.Login(params)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	ui.TextGreen().Printf("Successfully login as %s, %s\n", response.Name, response.Email)
 }
 
 func init() {

--- a/cli/cmd/login.go
+++ b/cli/cmd/login.go
@@ -11,7 +11,6 @@ import (
 	"github.com/Seiya-Tagami/pecopeco-cli/auth/secret"
 	"github.com/Seiya-Tagami/pecopeco-cli/config"
 	"github.com/Seiya-Tagami/pecopeco-cli/ui"
-	"github.com/briandowns/spinner"
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2/google"
 )
@@ -68,9 +67,7 @@ func login() {
 
 	ui.TextGreen().Printf("Authentication complete.\n\n")
 
-	sp := spinner.New(spinner.CharSets[21], 100*time.Millisecond)
-	sp.Color("green")
-	sp.Suffix = " Logging in..."
+	sp := ui.DefaultSpinner("Logging in...")
 	sp.Start()
 
 	userinfo, err := userinfo.Get(ctx, oauth)

--- a/cli/cmd/logout.go
+++ b/cli/cmd/logout.go
@@ -1,0 +1,29 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/Seiya-Tagami/pecopeco-cli/config"
+	"github.com/Seiya-Tagami/pecopeco-cli/ui"
+	"github.com/spf13/cobra"
+)
+
+var logoutCmd = &cobra.Command{
+	Use:   "logout",
+	Short: "Logout from the pecopeco-cli",
+	Long:  "Logout from the pecopeco-cli",
+	Run: func(cmd *cobra.Command, args []string) {
+		logout()
+	},
+}
+
+func logout() {
+	if err := config.Revoke(config.PECOPECO_API_TOKEN); err != nil {
+		fmt.Println(err)
+	}
+	ui.TextGreen().Println("Successfully logout!")
+}
+
+func init() {
+	rootCmd.AddCommand(logoutCmd)
+}

--- a/cli/cmd/user.go
+++ b/cli/cmd/user.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"github.com/Seiya-Tagami/pecopeco-cli/api/factory/user"
+	"github.com/Seiya-Tagami/pecopeco-cli/config"
+	"github.com/Seiya-Tagami/pecopeco-cli/ui"
+	"github.com/spf13/cobra"
+)
+
+var userCmd = &cobra.Command{
+	Use:   "user",
+	Short: "Print the logged in user",
+	Long:  "Print the logged in user",
+	Run: func(cmd *cobra.Command, args []string) {
+		printLoggedInUser()
+	},
+}
+
+func printLoggedInUser() {
+	factory := user.CreateFactory()
+	if !config.IsLogin() {
+		ui.TextBlue().Println(errorMsg)
+		return
+	}
+	user, err := factory.FindUser()
+	if err != nil {
+		ui.TextBlue().Println(errorMsg)
+		return
+	}
+	ui.TextGreen().Printf("Logged in as %s, %s\n", user.Name, user.Email)
+}
+
+const errorMsg = "Sorry, you may have not logged in yet. Please login with following command.\n> pecopeco login\nFor more info, you can reach https://github.com/Seiya-Tagami/pecopeco"
+
+func init() {
+	rootCmd.AddCommand(userCmd)
+}

--- a/cli/cmd/user.go
+++ b/cli/cmd/user.go
@@ -17,11 +17,12 @@ var userCmd = &cobra.Command{
 }
 
 func printLoggedInUser() {
-	factory := user.CreateFactory()
 	if !config.IsLogin() {
 		ui.TextBlue().Println(errorMsg)
 		return
 	}
+
+	factory := user.CreateFactory()
 	user, err := factory.FindUser()
 	if err != nil {
 		ui.TextBlue().Println(errorMsg)

--- a/cli/config.yaml
+++ b/cli/config.yaml
@@ -1,1 +1,2 @@
-line_notify_api_token:
+line_notify_api_token: ""
+pecopeco_api_token: ""

--- a/cli/config/load.go
+++ b/cli/config/load.go
@@ -26,6 +26,7 @@ func Load() {
 func initConfigFile(configFilename string) error {
 	viper.SetConfigType("yaml")
 	viper.Set(LINE_NOTIFY_API_TOKEN, "")
+	viper.Set(PECOPECO_API_TOKEN, "")
 
 	err := viper.WriteConfigAs(configFilename)
 	if err != nil {

--- a/cli/config/manager.go
+++ b/cli/config/manager.go
@@ -1,0 +1,41 @@
+package config
+
+import (
+	"fmt"
+	"unicode/utf8"
+
+	"github.com/spf13/viper"
+)
+
+func Get(property string) string {
+	value := viper.GetString(property)
+	return value
+}
+
+// ローカルに存在しない場合のみ、保存
+func Save(property string, value string) error {
+	if viper.GetString(property) != "" {
+		return nil
+	}
+	viper.Set(property, value)
+	if err := viper.WriteConfig(); err != nil {
+		return fmt.Errorf("Error writing config file: %s\n", err)
+	}
+	return nil
+}
+
+func Revoke(property string) error {
+	viper.Set(property, "")
+	if err := viper.WriteConfig(); err != nil {
+		return fmt.Errorf("Error writing config file: %s\n", err)
+	}
+	return nil
+}
+
+func IsLogin() bool {
+	value := viper.GetString(PECOPECO_API_TOKEN)
+	if utf8.RuneCountInString(value) != 0 {
+		return true
+	}
+	return false
+}

--- a/cli/config/variables.go
+++ b/cli/config/variables.go
@@ -1,3 +1,6 @@
 package config
 
-const LINE_NOTIFY_API_TOKEN = "line_notify_api_token"
+const (
+	LINE_NOTIFY_API_TOKEN = "line_notify_api_token"
+	PECOPECO_API_TOKEN    = "pecopeco_api_token"
+)

--- a/cli/go.mod
+++ b/cli/go.mod
@@ -3,6 +3,7 @@ module github.com/Seiya-Tagami/pecopeco-cli
 go 1.21.1
 
 require (
+	github.com/briandowns/spinner v1.23.0
 	github.com/fatih/color v1.16.0
 	github.com/go-chi/chi/v5 v5.0.11
 	github.com/joho/godotenv v1.5.1
@@ -45,6 +46,7 @@ require (
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9 // indirect
 	golang.org/x/net v0.19.0 // indirect
 	golang.org/x/sys v0.15.0 // indirect
+	golang.org/x/term v0.15.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231120223509-83a465c0220f // indirect

--- a/cli/go.sum
+++ b/cli/go.sum
@@ -4,6 +4,8 @@ cloud.google.com/go/compute v1.23.3/go.mod h1:VCgBUoMnIVIR0CscqQiPJLAG25E3ZRZMzc
 cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGBW5aJ7UnBMY=
 cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/briandowns/spinner v1.23.0 h1:alDF2guRWqa/FOZZYWjlMIx2L6H0wyewPxo/CH4Pt2A=
+github.com/briandowns/spinner v1.23.0/go.mod h1:rPG4gmXeN3wQV/TsAY4w8lPdIM6RX3yqeBQJSrbXjuE=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/logex v1.2.1 h1:XHDu3E6q+gdHgsdTPH6ImJMIp436vR6MPtH8gP05QzM=
@@ -169,6 +171,8 @@ golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.15.0 h1:h48lPFYpsTvQJZF4EKyI4aLHaev3CxivZmv7yZig9pc=
 golang.org/x/sys v0.15.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/term v0.15.0 h1:y/Oo/a/q3IXu26lQgl04j/gjuBDOBlx7X6Om1j2CPW4=
+golang.org/x/term v0.15.0/go.mod h1:BDl952bC7+uMoWR75FIrCDx79TPU9oHkTZ9yRbYOrX0=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=

--- a/cli/ui/spinner.go
+++ b/cli/ui/spinner.go
@@ -1,0 +1,15 @@
+package ui
+
+import (
+	"time"
+
+	"github.com/briandowns/spinner"
+)
+
+func DefaultSpinner(text string) *spinner.Spinner {
+	sp := spinner.New(spinner.CharSets[21], 100*time.Millisecond)
+	sp.Color("green")
+	sp.Suffix = " " + text
+
+	return sp
+}


### PR DESCRIPTION
## 関連 issue
- issue close #40 

## 説明
- CLI上でログイン・ログアウトが行えるようにしました。

## 動作確認手順
1. `ddl.sql`が修正されているので、もう一度dockerを立ち上げなおします。
```bash
$ docker compose down db -v
$ make run-api
$ make it-db
$ mysql -uroot -ppeco_password
```
```sql
$ use peco_db;
$ show tables;
```
2. cliコンテナに接続します。
```
$ make run-cli
$ make it-cli
```
3. ログインしてみます。
```
$ go run main.go login

// 若干時間はかかりますが、結果としてが次が出力されます。
Successfully login as <名前>, <メールアドレス>


// この状態で再度ログインしてみると、次が出力されます。
You have already logged in as  <名前>, <メールアドレス>
To log in to another account, please log out of your current account first.
```
4. ログインユーザーの取得をします。
```
$ go run main.go user

// 結果としてが次が出力されます。
Logged in as <名前>, <メールアドレス>
```
5. ログアウトします。
```
$ go run main.go logout

// 結果として次が出力されます。
Successfully logout!

// ログアウト状態でユーザー確認すると次が出力されます。
$ go run main.go logout

Sorry, you may have not logged in yet. Please login with following command.
> pecopeco login
For more info, you can reach https://github.com/Seiya-Tagami/pecopeco
```
## 相談したいこと
- ログイン中にスピナーなどのアニメーションを付けるか、ログイン中ですなどの表示がされた方がUXが良いと思うので試し中です。（相談ではないかもですが）

## 確認して欲しいこと
- 一旦、気になる点を指摘していただければと思います！

## 参考 URL 等
