### PR TITLE
[service] レストランドメインのAPIを実装

### DIFF
--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -90,6 +90,10 @@ paths:
       responses:
         "204":
           description: "成功"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorResponse"
         "401":
           description: "認証エラー"
           content:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -88,6 +88,8 @@ paths:
       parameters:
         - $ref: "#/components/parameters/JWT"
       responses:
+        "204":
+          description: "成功"
         "401":
           description: "認証エラー"
           content:

--- a/docs/api/openapi.yaml
+++ b/docs/api/openapi.yaml
@@ -88,12 +88,6 @@ paths:
       parameters:
         - $ref: "#/components/parameters/JWT"
       responses:
-        "204":
-          description: "成功"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/ErrorResponse"
         "401":
           description: "認証エラー"
           content:

--- a/service/docker/db/script/ddl.sql
+++ b/service/docker/db/script/ddl.sql
@@ -8,7 +8,8 @@ drop table if exists users;
 create table users (
   id varchar(256) not null primary key,
   name varchar(256) not null,
-  email varchar(256) not null
+  email varchar(256) not null,
+  created_at datetime not null default now()
 ) charset=utf8;
 
 -- レストランテーブル
@@ -20,7 +21,7 @@ create table restaurants (
   nearest_station varchar(256) not null,
   address varchar(256) not null,
   url varchar(256) not null,
-  created_at datetime not null,
+  created_at datetime not null default now(),
   user_id varchar(256) not null,
   foreign key (user_id) references users (id)
 ) charset=utf8;

--- a/service/internal/domain/restaurant/restaurant.go
+++ b/service/internal/domain/restaurant/restaurant.go
@@ -1,0 +1,78 @@
+package restaurant
+
+import (
+	urlpkg "net/url"
+	"unicode/utf8"
+
+	errDomain "github.com/Seiya-Tagami/pecopeco-service/internal/domain/error"
+	ulid "github.com/Seiya-Tagami/pecopeco-service/pkg/uild"
+)
+
+type Restaurant struct {
+	ID             string
+	Name           string
+	Genre          string
+	NearestStation string
+	Address        string
+	URL            string
+	UserID         string
+}
+
+func NewRestaurant(
+	name string,
+	genre string,
+	nearestStation string,
+	address string,
+	url string,
+	userID string,
+) (*Restaurant, error) {
+	// 店舗名のバリデーション
+	if utf8.RuneCountInString(name) < nameLengthMin || utf8.RuneCountInString(name) > nameLengthMax {
+		return nil, errDomain.NewError("店舗名の値が不正です。")
+	}
+	// ジャンルのバリデーション
+	if utf8.RuneCountInString(genre) < genreLengthMin || utf8.RuneCountInString(genre) > genreLengthMax {
+		return nil, errDomain.NewError("ジャンルの値が不正です。")
+	}
+	// 最寄り駅のバリデーション
+	if utf8.RuneCountInString(nearestStation) < nearestStationLengthMin || utf8.RuneCountInString(nearestStation) > nearestStationLengthMax {
+		return nil, errDomain.NewError("最寄り駅の値が不正です。")
+	}
+	// 住所のバリデーション
+	if utf8.RuneCountInString(address) < addressLengthMin || utf8.RuneCountInString(address) > addressLengthMax {
+		return nil, errDomain.NewError("住所の値が不正です。")
+	}
+	// URLのフォーマットのチェック
+	if _, err := urlpkg.ParseRequestURI(url); err != nil {
+		return nil, errDomain.NewError("URLの値が不正です。")
+	}
+	return &Restaurant{
+		ID:             ulid.NewULID(),
+		Name:           name,
+		Genre:          genre,
+		NearestStation: nearestStation,
+		Address:        address,
+		URL:            url,
+		UserID:         userID,
+	}, nil
+}
+
+const (
+	nameLengthMax = 100
+	nameLengthMin = 1
+)
+
+const (
+	genreLengthMax = 30
+	genreLengthMin = 1
+)
+
+const (
+	nearestStationLengthMax = 30
+	nearestStationLengthMin = 1
+)
+
+const (
+	addressLengthMax = 100
+	addressLengthMin = 1
+)

--- a/service/internal/domain/restaurant/restaurant_repository.go
+++ b/service/internal/domain/restaurant/restaurant_repository.go
@@ -1,0 +1,12 @@
+package restaurant
+
+import (
+	"context"
+	"database/sql"
+)
+
+type RestaurantRepository interface {
+	SaveWithTx(ctx context.Context, tx *sql.Tx, restaurant *Restaurant) error
+	ListByUserID(ctx context.Context, userID string) ([]*Restaurant, error)
+	DeleteByIDWithTx(ctx context.Context, tx *sql.Tx, id string) error
+}

--- a/service/internal/infrastructure/repository/restaurant_repository.go
+++ b/service/internal/infrastructure/repository/restaurant_repository.go
@@ -1,0 +1,108 @@
+package repository
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"strings"
+
+	"github.com/Seiya-Tagami/pecopeco-service/internal/domain/restaurant"
+	restaurantDomain "github.com/Seiya-Tagami/pecopeco-service/internal/domain/restaurant"
+)
+
+type restaurantRepository struct {
+	db *sql.DB
+}
+
+func NewRestaurantRepository(db *sql.DB) restaurant.RestaurantRepository {
+	return &restaurantRepository{db: db}
+}
+
+func (rr *restaurantRepository) ListByUserID(ctx context.Context, userID string) ([]*restaurantDomain.Restaurant, error) {
+	fields := []string{
+		"id",
+		"name",
+		"genre",
+		"nearest_station",
+		"address",
+		"url",
+		"user_id",
+	}
+	query := fmt.Sprintf(
+		"select %s from restaurants where user_id = ?",
+		strings.Join(fields, ", "),
+	)
+
+	rows, err := rr.db.QueryContext(ctx, query, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	restaurants := []*restaurantDomain.Restaurant{}
+
+	for rows.Next() {
+		restaurant := &restaurantDomain.Restaurant{}
+		err = rows.Scan(
+			&restaurant.ID,
+			&restaurant.Name,
+			&restaurant.Genre,
+			&restaurant.NearestStation,
+			&restaurant.Address,
+			&restaurant.URL,
+			&restaurant.UserID,
+		)
+		if err != nil {
+			break
+		}
+		restaurants = append(restaurants, restaurant)
+	}
+
+	defer rows.Close()
+
+	if err != nil {
+		return nil, err
+	}
+	return restaurants, nil
+}
+
+func (rr *restaurantRepository) SaveWithTx(ctx context.Context, tx *sql.Tx, restaurant *restaurant.Restaurant) error {
+	fields := []string{
+		"id",
+		"name",
+		"genre",
+		"nearest_station",
+		"address",
+		"url",
+		"user_id",
+	}
+	query := fmt.Sprintf(
+		"insert into restaurants (%s) values (?, ?, ?, ?, ?, ?, ?)",
+		strings.Join(fields, ", "),
+	)
+	_, err := tx.ExecContext(
+		ctx,
+		query,
+		restaurant.ID,
+		restaurant.Name,
+		restaurant.Genre,
+		restaurant.NearestStation,
+		restaurant.Address,
+		restaurant.URL,
+		restaurant.UserID,
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (rr *restaurantRepository) DeleteByIDWithTx(ctx context.Context, tx *sql.Tx, id string) error {
+	query := "delete from restaurants where id = ?"
+
+	_, err := tx.ExecContext(ctx, query, id)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/service/internal/presentation/responder/responder.go
+++ b/service/internal/presentation/responder/responder.go
@@ -17,6 +17,11 @@ func ReturnStatusOK[T any](w http.ResponseWriter, body T) {
 	returnResponse[T](w, body, http.StatusOK)
 }
 
+// 204
+func ReturnStatusNoContent(w http.ResponseWriter) {
+	w.WriteHeader(http.StatusNoContent)
+}
+
 // 400
 func ReturnStatusBadRequest(w http.ResponseWriter, err error) {
 	response := ErrorResponse{

--- a/service/internal/presentation/restaurant/handler.go
+++ b/service/internal/presentation/restaurant/handler.go
@@ -1,0 +1,139 @@
+package restaurant
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/Seiya-Tagami/pecopeco-service/internal/presentation/responder"
+	"github.com/Seiya-Tagami/pecopeco-service/internal/presentation/util/httputil"
+	restaurantUseCase "github.com/Seiya-Tagami/pecopeco-service/internal/usecase/restaurant"
+	"github.com/Seiya-Tagami/pecopeco-service/internal/util/jwt"
+	"github.com/Seiya-Tagami/pecopeco-service/pkg/validator"
+	"github.com/go-chi/chi/v5"
+)
+
+type handler struct {
+	listRestaurantsUseCase  *restaurantUseCase.ListRestaurantsUseCase
+	saveRestaurantUsecase   *restaurantUseCase.SaveRestaurantUseCase
+	deleteRestaurantUseCase *restaurantUseCase.DeleteRestaurantUseCase
+}
+
+func NewHandler(
+	listRestaurantsUseCase *restaurantUseCase.ListRestaurantsUseCase,
+	saveRestaurantUsecase *restaurantUseCase.SaveRestaurantUseCase,
+	deleteRestaurantUseCase *restaurantUseCase.DeleteRestaurantUseCase,
+) handler {
+	return handler{
+		listRestaurantsUseCase:  listRestaurantsUseCase,
+		saveRestaurantUsecase:   saveRestaurantUsecase,
+		deleteRestaurantUseCase: deleteRestaurantUseCase,
+	}
+}
+
+func (h *handler) ListRestaurants(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	accessToken := r.Header.Get("Authorization")
+	userID, err := jwt.GetUserIDFromToken(accessToken)
+	if err != nil {
+		responder.ReturnStatusUnauthorized(w, err)
+		return
+	}
+
+	dtos, err := h.listRestaurantsUseCase.Run(ctx, userID)
+	if err != nil {
+		responder.ReturnStatusInternalServerError(w, err)
+		return
+	}
+
+	// 何も取得できなかった場合は、長さ0の配列で返すようにする
+	if len(dtos) == 0 {
+		responder.ReturnStatusOK(w, ListRestaurantsResponse{Restaurants: []RestaurantResponse{}})
+		return
+	}
+
+	var response ListRestaurantsResponse
+
+	for _, v := range dtos {
+		response.Restaurants = append(
+			response.Restaurants,
+			RestaurantResponse{
+				ID:             v.ID,
+				Name:           v.Name,
+				Genre:          v.Genre,
+				NearestStation: v.NearestStation,
+				Address:        v.Address,
+				URL:            v.URL,
+			},
+		)
+	}
+	responder.ReturnStatusOK(w, response)
+}
+
+func (h *handler) SaveRestaurant(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	accessToken := r.Header.Get("Authorization")
+	userID, err := jwt.GetUserIDFromToken(accessToken)
+	if err != nil {
+		responder.ReturnStatusUnauthorized(w, err)
+		return
+	}
+
+	params := PostRestaurantParams{}
+	if err := httputil.ParseJSONRequestBody(r, &params); err != nil {
+		responder.ReturnStatusInternalServerError(w, err)
+		return
+	}
+
+	validate := validator.Get()
+	if err := validate.Struct(&params); err != nil {
+		responder.ReturnStatusBadRequest(w, err)
+		return
+	}
+
+	inputDto := restaurantUseCase.SaveRestaurantUseCaseInputDto{
+		Name:           params.Name,
+		Genre:          params.Genre,
+		NearestStation: params.NearestStation,
+		Address:        params.Address,
+		URL:            params.URL,
+		UserID:         userID,
+	}
+
+	outputDto, err := h.saveRestaurantUsecase.Run(ctx, inputDto)
+	if err != nil {
+		responder.ReturnStatusInternalServerError(w, err)
+		return
+	}
+
+	response := PostRestaurantResponse{
+		ID:             outputDto.Name,
+		Name:           outputDto.Name,
+		Genre:          outputDto.Genre,
+		NearestStation: outputDto.NearestStation,
+		Address:        outputDto.Address,
+		URL:            outputDto.URL,
+	}
+	responder.ReturnStatusOK(w, response)
+}
+
+func (h *handler) DeleteRestaurant(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	ctx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	restaurantID := chi.URLParam(r, "id")
+
+	err := h.deleteRestaurantUseCase.Run(ctx, restaurantID)
+	if err != nil {
+		responder.ReturnStatusInternalServerError(w, err)
+		return
+	}
+	responder.ReturnStatusNoContent(w)
+}

--- a/service/internal/presentation/restaurant/handler.go
+++ b/service/internal/presentation/restaurant/handler.go
@@ -113,7 +113,7 @@ func (h *handler) SaveRestaurant(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response := PostRestaurantResponse{
-		ID:             outputDto.Name,
+		ID:             outputDto.ID,
 		Name:           outputDto.Name,
 		Genre:          outputDto.Genre,
 		NearestStation: outputDto.NearestStation,

--- a/service/internal/presentation/restaurant/request.go
+++ b/service/internal/presentation/restaurant/request.go
@@ -1,0 +1,9 @@
+package restaurant
+
+type PostRestaurantParams struct {
+	Name           string `json:"name" validate:"required"`
+	Genre          string `json:"genre" validate:"required"`
+	NearestStation string `json:"nearest_station" validate:"required"`
+	Address        string `json:"address" validate:"required"`
+	URL            string `json:"url" validate:"required"`
+}

--- a/service/internal/presentation/restaurant/response.go
+++ b/service/internal/presentation/restaurant/response.go
@@ -1,0 +1,16 @@
+package restaurant
+
+type RestaurantResponse struct {
+	ID             string `json:"id"`
+	Name           string `json:"name"`
+	Genre          string `json:"genre"`
+	NearestStation string `json:"nearest_station"`
+	Address        string `json:"address"`
+	URL            string `json:"url"`
+}
+
+type ListRestaurantsResponse struct {
+	Restaurants []RestaurantResponse `json:"restaurants"`
+}
+
+type PostRestaurantResponse = RestaurantResponse

--- a/service/internal/usecase/restaurant/delete_restaurant_usecase.go
+++ b/service/internal/usecase/restaurant/delete_restaurant_usecase.go
@@ -1,0 +1,40 @@
+package restaurant
+
+import (
+	"context"
+
+	"github.com/Seiya-Tagami/pecopeco-service/internal/db"
+	"github.com/Seiya-Tagami/pecopeco-service/internal/domain/restaurant"
+)
+
+type DeleteRestaurantUseCase struct {
+	restaurantRepo restaurant.RestaurantRepository
+}
+
+func NewDeleteRestaurantsUseCase(
+	restaurantRepo restaurant.RestaurantRepository,
+) *DeleteRestaurantUseCase {
+	return &DeleteRestaurantUseCase{
+		restaurantRepo: restaurantRepo,
+	}
+}
+
+func (uc *DeleteRestaurantUseCase) Run(ctx context.Context, id string) error {
+	db := db.GetDB()
+	tx, err := db.Begin()
+	if err != nil {
+		return err
+	}
+
+	err = uc.restaurantRepo.DeleteByIDWithTx(ctx, tx, id)
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+
+	if err = tx.Commit(); err != nil {
+		tx.Rollback()
+		return err
+	}
+	return nil
+}

--- a/service/internal/usecase/restaurant/list_restaurants_usecase.go
+++ b/service/internal/usecase/restaurant/list_restaurants_usecase.go
@@ -1,0 +1,51 @@
+package restaurant
+
+import (
+	"context"
+
+	restaurantDomain "github.com/Seiya-Tagami/pecopeco-service/internal/domain/restaurant"
+)
+
+type ListRestaurantsUseCase struct {
+	restaurantRepo restaurantDomain.RestaurantRepository
+}
+
+func NewListRestaurantsUseCase(
+	restaurantRepo restaurantDomain.RestaurantRepository,
+) *ListRestaurantsUseCase {
+	return &ListRestaurantsUseCase{
+		restaurantRepo: restaurantRepo,
+	}
+}
+
+type ListRestaurantsUseCaseDto struct {
+	ID             string
+	Name           string
+	Genre          string
+	NearestStation string
+	Address        string
+	URL            string
+	UserID         string
+}
+
+func (uc *ListRestaurantsUseCase) Run(ctx context.Context, userID string) ([]*ListRestaurantsUseCaseDto, error) {
+	restaurants, err := uc.restaurantRepo.ListByUserID(ctx, userID)
+	if err != nil {
+		return nil, err
+	}
+
+	dtos := make([]*ListRestaurantsUseCaseDto, 0, len(restaurants))
+
+	for _, v := range restaurants {
+		dtos = append(dtos, &ListRestaurantsUseCaseDto{
+			ID:             v.ID,
+			Name:           v.Name,
+			Genre:          v.Genre,
+			NearestStation: v.NearestStation,
+			Address:        v.Address,
+			URL:            v.URL,
+			UserID:         v.UserID,
+		})
+	}
+	return dtos, nil
+}

--- a/service/internal/usecase/restaurant/save_restaurant_usecase.go
+++ b/service/internal/usecase/restaurant/save_restaurant_usecase.go
@@ -1,0 +1,72 @@
+package restaurant
+
+import (
+	"context"
+
+	"github.com/Seiya-Tagami/pecopeco-service/internal/db"
+	restaurantDomain "github.com/Seiya-Tagami/pecopeco-service/internal/domain/restaurant"
+)
+
+type SaveRestaurantUseCase struct {
+	restaurantRepo restaurantDomain.RestaurantRepository
+}
+
+func NewSaveRestaurantUseCase(
+	restaurantRepo restaurantDomain.RestaurantRepository,
+) *SaveRestaurantUseCase {
+	return &SaveRestaurantUseCase{
+		restaurantRepo: restaurantRepo,
+	}
+}
+
+type SaveRestaurantUseCaseInputDto struct {
+	Name           string
+	Genre          string
+	NearestStation string
+	Address        string
+	URL            string
+	UserID         string
+}
+
+type SaveRestaurantUseCaseOutputDto struct {
+	ID             string
+	Name           string
+	Genre          string
+	NearestStation string
+	Address        string
+	URL            string
+	UserID         string
+}
+
+func (uc *SaveRestaurantUseCase) Run(ctx context.Context, dto SaveRestaurantUseCaseInputDto) (*SaveRestaurantUseCaseOutputDto, error) {
+	restaurant, err := restaurantDomain.NewRestaurant(dto.Name, dto.Genre, dto.NearestStation, dto.Address, dto.URL, dto.UserID)
+	if err != nil {
+		return nil, err
+	}
+
+	db := db.GetDB()
+	tx, err := db.Begin()
+	if err != nil {
+		return nil, err
+	}
+
+	if err = uc.restaurantRepo.SaveWithTx(ctx, tx, restaurant); err != nil {
+		tx.Rollback()
+		return nil, err
+	}
+
+	if err = tx.Commit(); err != nil {
+		tx.Rollback()
+		return nil, err
+	}
+
+	return &SaveRestaurantUseCaseOutputDto{
+		ID:             restaurant.ID,
+		Name:           restaurant.Name,
+		Genre:          restaurant.Genre,
+		NearestStation: restaurant.NearestStation,
+		Address:        restaurant.Address,
+		URL:            restaurant.URL,
+		UserID:         restaurant.UserID,
+	}, nil
+}


### PR DESCRIPTION
## 関連 issue
- issue close #28 

## 説明
- レストランドメインのAPIを実装しました。
- DBスキーマでミスがあったので、また修正しています。何度もすみません🙏

## 動作確認手順
1. `ddl.sql`を流すために、dockerを再起動します。そして、dbコンテナに接続してログインし、テーブルの存在を確認します。
```bash
$ docker compose down db -v
$ make run-api
$ make it-db
$ mysql -uroot -ppeco_password
```
```sql
$ use peco_db;
$ show tables;
```
3. apiコンテナに接続し、サーバーを起動します。
```bash
$ make it-api
$ go run main.go
```
4. まずログインします。
```
POST: http://localhost:8080/v1/users/login

// request
{
    "id": "1",
    "name": "test1",
    "email": "test1@gmail.com"
}

// response
{
    "id": "1",
    "name": "test1",
    "email": "test1@gmail.com"
}
```
2. `Authorization`ヘッダの値をコピペします。
3. レストランのAPIを叩きます。リクエストの`Authorization`ヘッダに先ほどの値を付しておきます。次のような結果になれば問題ないです。
```
登録
POST: http://localhost:8080/v1/restaurants

// request
{
    "name": "ステーキ屋",
    "genre": "洋食",
    "nearest_station": "渋谷",
    "address": "東京都渋谷区道玄坂xxxxxxxx",
    "url": "https://example.com"
}

// response
{
    "name": "ステーキ屋",
    "genre": "洋食",
    "nearest_station": "渋谷",
    "address": "東京都渋谷区道玄坂xxxxxxxx",
    "url": "https://example.com"
}


全件取得
GET: http://localhost:8080/v1/restaurants
// response
{
    "restaurants": [
        {
            "id": "01HPCBKPQJBP0QC82K1TJM6WAC",
            "name": "ステーキ屋",
            "genre": "洋食",
            "nearest_station": "渋谷",
            "address": "東京都渋谷区道玄坂xxxxxxxx",
            "url": "https://example.com"
        }
    ]
}


削除
// DELETE: http://localhost:8080/v1/restaurants/{id}
// response
No Content 204
```
## 相談したいこと

## 確認して欲しいこと
- 気になるところを指摘していただければと思います！

## 参考 URL 等
